### PR TITLE
Specify key for sorting blog archive

### DIFF
--- a/src/collective/blogging/portlets/archive.py
+++ b/src/collective/blogging/portlets/archive.py
@@ -137,7 +137,7 @@ class Renderer(base.Renderer):
                 'months': sorted([(m, c, '%s&publish_month=%s' % (year_url, m), PLMF(ts.month_msgid(m), default=ts.month_english(m))) \
                                     for m,c in archives[archive]['entries'].items()], reverse=True)
             })
-        return sorted(result, reverse=True)
+        return sorted(result, key=lambda archive: archive['year'], reverse=True)
     
     @instance.memoize
     def blog(self):


### PR DESCRIPTION
Specify the year as the key for sorting the blog archive. It might be sorted by the wrong key, for example by count, see screenshot.

![screen shot 2013-11-18 at 14 21 13](https://f.cloud.github.com/assets/5045627/1562918/79780674-5054-11e3-9a7b-b4156dd84c24.png)
