### PR TITLE
Fix: PathExpr error in 'view/commetns_allowed'.

### DIFF
--- a/src/collective/blogging/browser/entry_macros.pt
+++ b/src/collective/blogging/browser/entry_macros.pt
@@ -85,7 +85,7 @@
         tal:define="toLocalizedTime nocall:toLocalizedTime|nocall:context/@@plone/toLocalizedTime;                                
                     item_url    context/absolute_url;
                     item_date   python:toLocalizedTime(context.Date(),long_format=1);
-                    commetns_allowed    view/commetns_allowed;
+                    comments_allowed    view/comments_allowed;
                     reply_count view/reply_count;">
 
         <tal:block tal:condition="python:item_date and item_date != None">
@@ -94,7 +94,7 @@
             </span>
         </tal:block>
         
-        <tal:block tal:condition="commetns_allowed|nothing">
+        <tal:block tal:condition="comments_allowed|nothing">
             |
             <a title="Read comments on this entry."
                 class="actionComments"


### PR DESCRIPTION
This is a typo, should be 'view/comments_allowed'. Introduced in commit 0e978d02 and thus release 1.3.1.
